### PR TITLE
feat: separate rule for fonts and images and replace use with type

### DIFF
--- a/scripts/configs/webpack.build.config.js
+++ b/scripts/configs/webpack.build.config.js
@@ -129,13 +129,12 @@ exports.setupWebpackBuildConfig = (options, { basePath, commitHash }, skipCustom
 					]
 				},
 				{
-					test: /\.(png|jpg|gif|woff2?|eot|ttf|ogg|mp3)$/,
-					use: [
-						{
-							loader: require.resolve('file-loader'),
-							options: {}
-						}
-					]
+					test: /\.(png|jpg|gif|ogg|mp3)$/,
+					type: 'asset/resource'
+				},
+				{
+					test: /\.(woff(2)?|ttf|eot)$/,
+					type: 'asset/resource'
 				},
 				{
 					test: /\.hbs$/,

--- a/scripts/configs/webpack.external.config.js
+++ b/scripts/configs/webpack.external.config.js
@@ -25,13 +25,12 @@ exports.setupWebpackExternalBuildConfig = (options, { basePath }) => {
 					options: createBabelConfig(`babel.config.js`)
 				},
 				{
-					test: /\.(png|jpg|gif|woff2?|svg|eot|ttf|ogg|mp3)$/,
-					use: [
-						{
-							loader: require.resolve('file-loader'),
-							options: {}
-						}
-					]
+					test: /\.(png|jpg|gif|svg|ogg|mp3)$/,
+					type: 'asset/resource'
+				},
+				{
+					test: /\.(woff(2)?|ttf|eot)$/,
+					type: 'asset/resource'
 				}
 			]
 		},


### PR DESCRIPTION
Separate rules for fonts in order to be able to override it in other projects.
Update how resources are loaded to use [webpack 5 asset modules](https://webpack.js.org/guides/asset-modules/) 