### PR TITLE
fix: replace fileloader reference

### DIFF
--- a/scripts/configs/webpack.build.config.js
+++ b/scripts/configs/webpack.build.config.js
@@ -155,11 +155,7 @@ exports.setupWebpackBuildConfig = (options, { basePath, commitHash }, skipCustom
 				},
 				{
 					test: /\.svg$/,
-					use: [
-						options.svgr ? '@svgr/webpack' : {
-							loader: require.resolve('file-loader')
-						}
-					]
+					type: 'asset/resource'
 				}
 			]
 		},

--- a/scripts/configs/webpack.build.config.js
+++ b/scripts/configs/webpack.build.config.js
@@ -155,7 +155,11 @@ exports.setupWebpackBuildConfig = (options, { basePath, commitHash }, skipCustom
 				},
 				{
 					test: /\.svg$/,
-					type: 'asset/resource'
+					...options.svgr ? {
+						use: ['@svgr/webpack']
+					} : {
+						type: 'asset/resource'
+					}
 				}
 			]
 		},


### PR DESCRIPTION
Resolve bug in svg loading due to an old file-loader dependency
More info: https://webpack.js.org/guides/asset-modules/#:~:text=Asset%20Modules%20is,asset%20size%20limit.