### PR TITLE
chore(pkgbuild): update package installation commands

### DIFF
--- a/.nvmrc.license
+++ b/.nvmrc.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Zextras <https://www.zextras.com>
+SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
 
 SPDX-License-Identifier: CC0-1.0

--- a/scripts/configs/PKGBUILD.template
+++ b/scripts/configs/PKGBUILD.template
@@ -21,15 +21,20 @@ depends=(
   "carbonio-webui-i18n"
   "jq"
 )
+source=(
+  '<%- htmlWebpackPlugin.options.name %>-dist.tar.gz'
+)
+sha256sums=(
+  'SKIP'
+)
 
 package() {
-  cd "${srcdir}"
-  mkdir -p "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
-  cp -a  ../../dist/* "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
-  chown root:root -R "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
-  chmod 644 -R "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
-  find "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>" -type d -exec chmod a+x "{}" \;
-  ln -sf /opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/i18n "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>/i18n"
+  install -dm755 \
+    "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
+  cp -a  "${srcdir}/dist/"* \
+    "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>"
+  ln -sf /opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/i18n \
+    "${pkgdir}/opt/zextras/<%- htmlWebpackPlugin.options.installMode %>/iris/${pkgname}/<%- htmlWebpackPlugin.options.commit %>/i18n"
 }
 
 postinst() {

--- a/scripts/configs/PKGBUILD.template.license
+++ b/scripts/configs/PKGBUILD.template.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Zextras <https://www.zextras.com>
+SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
 
 SPDX-License-Identifier: AGPL-3.0-only

--- a/scripts/configs/component.template.license
+++ b/scripts/configs/component.template.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2021 Zextras <https://www.zextras.com>
+SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
 
 SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
Improvements:

* Add source for compiled dist artifacts
* Update package function to use sources

Fyi: these changes are incompatible with  `jenkins-zapp-lib@github-pipeline-v4`.
When upgrading `carbonio-ui-sdk` in ui projects, please migrate to `jenkins-zapp-lib@1.0.0`.
Changes have already been made in affected repositories in branch `chore/IN-930-streamline-pipeline`
    
Refs: IN-930 IN-908