### PR TITLE
fix(deploy): use relative symlink for i18n in container deploy

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -214,7 +214,8 @@ export const handler = async (options: DeployOptions) => {
     execSync(`docker exec ${options.container} sh -c '
         find ${pathPrefix}${options.name} -mindepth 1 -name i18n -prune -o -exec rm -rf {} + &&
         cd ${pathPrefix} && mkdir -p ${options.name}/${commitHash} ${options.name}/current &&
-        ln -sf ${pathPrefix}/${options.name}/i18n "${pathPrefix}/${options.name}/${commitHash}/i18n"
+        cd ${options.name}/${commitHash} &&
+        ln -sf "../i18n" "i18n"
     '`);
 
     execSync(


### PR DESCRIPTION
## Summary

- Allinea il container deploy al local directory deploy usando un symlink relativo (`../i18n`) invece di un path assoluto
- Rimuove il bug del doppio slash (`pathPrefix` termina già con `/`, il vecchio codice aggiungeva un'ulteriore `/`)
- Il symlink relativo è più robusto se il path viene rimontato su un container diverso

## Also Require

- https://github.com/zextras/carbonio-dockerization/pull/64

## Test plan

- [ ] Verificare che il deploy verso un container Docker crei correttamente il symlink `i18n` dentro la directory `<commitHash>/`
- [ ] Verificare che le traduzioni siano accessibili dopo il deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)