### PR TITLE
fix(release): add build and refactor types to release notes generator

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -31,6 +31,15 @@ export default {
       "@semantic-release/release-notes-generator",
       {
         preset: "conventionalcommits",
+        presetConfig: {
+          types: [
+            { type: "feat", section: "Features" },
+            { type: "fix", section: "Bug Fixes" },
+            { type: "perf", section: "Performance Improvements" },
+            { type: "refactor", section: "Code Refactoring" },
+            { type: "build", section: "Build System" },
+          ],
+        },
       },
     ],
     "@semantic-release/npm",


### PR DESCRIPTION
The commit-analyzer was configured to trigger patch releases for `build` and `refactor` commits, but the release-notes-generator had no matching `types` configuration. This caused v2.2.5 (triggered by the pnpm migration `build:` commit) to be released with an empty changelog.

Add explicit `presetConfig.types` to the release-notes-generator so that `build` and `refactor` commits appear in their own sections.